### PR TITLE
Do nothing if quote has no skus

### DIFF
--- a/src/Spryker/Zed/ProductCartConnector/Business/InactiveItemsFilter/InactiveItemsFilter.php
+++ b/src/Spryker/Zed/ProductCartConnector/Business/InactiveItemsFilter/InactiveItemsFilter.php
@@ -64,6 +64,9 @@ class InactiveItemsFilter implements InactiveItemsFilterInterface
     public function filterInactiveItems(QuoteTransfer $quoteTransfer): QuoteTransfer
     {
         $skus = $this->getProductSkusFromQuoteTransfer($quoteTransfer);
+        if (count($skus) === 0) {
+            return $quoteTransfer;
+        }
         $productCriteriaTransfer = (new ProductCriteriaTransfer())
             ->setSkus($skus)
             ->setIsActive(true)


### PR DESCRIPTION
## PR Description

If the quote has no SKUs, the filter will do a linear scan of the entire database with is_active=true and store=X criteria, which is expensive.

## Checklist
- [ x ] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
